### PR TITLE
Mention all authors

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,12 @@
+{
+    "title": "Theory of Sound Field Synthesis",
+    "creators": [{ "name": "Wierstorf et al., Hagen" }],
+    "description": "Discussion of the theory of sound field synthesis, see https://sfs.readthedocs.io",
+    "license": "Creative Commons Attribution 4.0",
+    "keywords": [
+        "sound field synthesis",
+        "WFS",
+        "NFC-HOA",
+        "SFS"
+    ]
+}

--- a/conf.py
+++ b/conf.py
@@ -150,7 +150,7 @@ latex_documents = [
     (master_doc,
      'sfs-toolbox-documentation.tex',
      u'Theory of Sound Field Synthesis',
-     u'H. Wierstorf, F. Winter, F. Schultz, N. Hahn,\\\\T. Rettberg, C. Hohnerlein, and S. Spors',
+     u'H. Wierstorf et al.',
      'manual',
      True),
 ]

--- a/contributors.rst
+++ b/contributors.rst
@@ -1,0 +1,40 @@
+.. _contributors:
+
+Contributors
+------------
+
+The following individuals have contributed significantly to the Sound Field
+Synthesis Toolbox. If you think more people should be listed here, feel free to
+create a pull request.
+
+=============== ============
+Name            GitHub
+=============== ============
+Hagen Wierstorf `hagenw`_
+Fiete Winter    `fietew`_
+Matthias Geier  `mgeier`_
+Frank Schultz   `fs446`_
+Nara Hahn       `narahahn`_
+Till Rettberg   `trettberg`_
+Christoph Hold  `chris-hld`_
+Vera Erbes      `VeraE`_
+Sascha Spors    `spors`_
+=============== ============
+
+Furthermore, all github contributions can be found on the specific project
+pages:
+
+* https://github.com/sfstoolbox/theory/graphs/contributors
+* https://github.com/sfstoolbox/sfs-matlab/graphs/contributors
+* https://github.com/sfstoolbox/sfs-python/graphs/contributors
+
+
+.. _hagenw: https://github.com/hagenw
+.. _fietew: https://github.com/fietew
+.. _mgeier: https://github.com/mgeier
+.. _fs446: https://github.com/fs446
+.. _narahahn: https://github.com/narahahn
+.. _trettberg: https://github.com/trettberg
+.. _chris-hld: https://github.com/chris-hld
+.. _VeraE: https://github.com/VeraE
+.. _spors: https://github.com/spors

--- a/index.rst
+++ b/index.rst
@@ -76,6 +76,7 @@ Table of Contents
 .. toctree::
     :maxdepth: 3
 
+    contributors
     defs/index
     problem/index
     nfchoa/index

--- a/index.rst
+++ b/index.rst
@@ -63,8 +63,7 @@ You can link to any equation within it by the permalink that becomes visible by
 hovering over the corresponding equation number, e.g.
 :sfs:`wfs/#equation-D_wfs`. Those links will always work.
 If you prefer to reference an equation from the :get:`pdf` instead, please cite
-the document with "H. Wierstorf, F. Winter, F. Schultz, N. Hahn, T. Rettberg, C.
-Hohnerlein, and S. Spors. *Theory of Sound Field Synthesis*.
+the document with "H. Wierstorf et al. *Theory of Sound Field Synthesis*.
 `doi:10.5281/zenodo.1112451`_."
 
 .. _`doi:10.5281/zenodo.1112451`: https://doi.org/10.5281/zenodo.1112451


### PR DESCRIPTION
This is an implementation of the third option that @mgeier proposed in his email from 2017-12-18.

It changes the citation style of the document to "H. Wierstorf et al., Theory of Sound Field Synthesis" and adds an extra chapter "Contributors" with a table of the main authors and links to all github contributions.

It also adds metadata definitions for zenodo to allow automatic github releases. This is not tested as I guess we have to make a release to test it.

Note, this is kind of a proposal, feel free to criticize it.

The final result can be seen here:
http://sfstoolbox.org/en/v3-authors/, especially the contributors chapter: http://sfstoolbox.org/en/v3-authors/contributors/