### PR TITLE
Rename equation labels

### DIFF
--- a/d_lsfs/index.rst
+++ b/d_lsfs/index.rst
@@ -28,7 +28,7 @@ supported. The resulting driving function for a loudspeaker located at
 :math:`\x_0` reads
 
 .. math::
-    :label: D.localwfs
+    :label: d-localwfs-frequency-domain
 
     D(\x_0,\w) = \sum_{{\x_\text{fs}}\in \mathcal{X}_{\mathrm{fs}}}
         D_{\mathrm l}({\x_\text{fs}}, \w)
@@ -42,7 +42,7 @@ source at :math:`{\x_\text{fs}}` weighted by :math:`D_\text{l}({\x_\text{fs}},
 This yields
 
 .. math::
-    :label: D.localwfs.fs
+    :label: d-localwfs-focused-source-frequency-domain
 
     D_{\mathrm{fs}}(\x_0,{\x_\text{fs}},\w) =
         \frac{1}{2\pi} A(\w) w(\x_0) \i\wc 
@@ -53,7 +53,7 @@ This yields
 and
 
 .. math::
-    :label: D.localwfs.fs.2.5D
+    :label: d-localwfs-focused-source-25d-frequency-domain
 
     D_{\mathrm{fs,2.5D}}(\x_0,{\x_\text{fs}},\w) = 
        \frac{g_0}{2\pi} A(\w) w(\x_0) \sqrt{\i\wc }
@@ -64,7 +64,7 @@ for the 2.5D case. For the temporal domain, inverse Fourier transform yields the
 driving signals
 
 .. math::
-    :label: d.localwfs
+    :label: d-localwfs-focused-source-time-domain
 
     d(\x_0,t) = \sum_{{\x_\text{fs}}\in \mathcal{X}_{\mathrm{fs}}} 
         d_{\mathrm l}({\x_\text{fs}}, t) * 

--- a/d_nfchoa/index.rst
+++ b/d_nfchoa/index.rst
@@ -51,17 +51,17 @@ Plane Wave
     :align: center
 
     Sound pressure for a monochromatic plane wave synthesized with 2.5D
-    |NFC-HOA| :eq:`D.nfchoa.pw.2.5D`.  Parameters: :math:`\n_k = (0, -1, 0)`,
-    :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
+    |NFC-HOA| :eq:`d-nfchoa-plane-wave-25d-frequency-domain`.  Parameters:
+    :math:`\n_k = (0, -1, 0)`, :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
 
 For a spherical secondary source distribution with radius :math:`R_0` the
 spherical expansion coefficients of a plane
 wave :eq:`plane-wave-spherical-coefficients` and of the Green’s function for a
-point source :eq:`G_spherical` are inserted into :eq:`D_spherical` and yield
-:cite:`Schultz2014`, eq. (A3)
+point source :eq:`g-spherical-frequency-domain` are inserted
+into :eq:`d-spherical-frequency-domain` and yield :cite:`Schultz2014`, eq. (A3)
 
 .. math::
-    :label: D.nfchoa.pw.3D
+    :label: d-nfchoa-plane-wave-3d-frequency-domain
 
     D_\text{spherical}(\theta_0,\phi_0,\w) = -A(\w)
         \frac{4\pi}{R_0^{\,2}} \sum_{n=0}^\infty \sum_{m=-n}^n
@@ -72,11 +72,11 @@ point source :eq:`G_spherical` are inserted into :eq:`D_spherical` and yield
 For a circular secondary source distribution with radius :math:`R_0` the
 circular expansion coefficients of a plane
 wave :eq:`plane-wave-circular-coefficients` and of the Green’s function for a
-line source :eq:`G_circular` are inserted into :eq:`D_circular` and yield
-:cite:`Ahrens2009a`, eq. (16)
+line source :eq:`g-circular-frequency-domain` are inserted
+into :eq:`d-circular-frequency-domain` and yield :cite:`Ahrens2009a`, eq. (16)
 
 .. math::
-    :label: D.nfchoa.pw.2D
+    :label: d-nfchoa-plane-wave-2d-frequency-domain
 
     D_\text{circular}(\phi_0,\w) = -A(\w) \frac{2\i}{\pi R_0}
         \sum_{m=-\infty}^\infty \frac{\i^{-m}\Phi_{-m}(\phi_k)}
@@ -86,10 +86,11 @@ For a circular secondary source distribution with radius :math:`R_0` and point
 source as Green’s function the 2.5D driving function is given by inserting the
 spherical expansion coefficients for a plane
 wave :eq:`plane-wave-spherical-coefficients` and a point
-source :eq:`point-source-spherical-coefficients` into :eq:`D_circular_25D` as
+source :eq:`point-source-spherical-coefficients`
+into :eq:`d-circular-25d-frequency-domain` as
 
 .. math::
-    :label: D.nfchoa.pw.2.5D
+    :label: d-nfchoa-plane-wave-25d-frequency-domain
 
     D_{\text{circular},\,\text{2.5D}}(\phi_0,\w) = -A(\w)
         \frac{2}{R_0} \sum_{m=-\infty}^\infty
@@ -100,13 +101,13 @@ For an infinite linear secondary source distribution located on the
 :math:`x`-axis the 2.5D driving function is given by inserting the linear
 expansion coefficients for a point source as Green’s
 function :eq:`point-source-linear-coefficients` and a plane
-wave :eq:`plane-wave-linear-coefficients` into :eq:`D_linear_25D` and exploiting
-the fact that :math:`(\wc )^2 - k_{x_\text{s}}` is constant.
-Assuming :math:`0 \le |k_{x_\text{s}}| \le |\wc |` this results in
-:cite:`Ahrens2010`, eq. (17)
+wave :eq:`plane-wave-linear-coefficients`
+into :eq:`d-linear-25d-frequency-domain` and exploiting the fact that
+:math:`(\wc )^2 - k_{x_\text{s}}` is constant.  Assuming :math:`0 \le
+|k_{x_\text{s}}| \le |\wc |` this results in :cite:`Ahrens2010`, eq. (17)
 
 .. math::
-    :label: D.sdm.pw.2.5D
+    :label: d-sdm-plane-wave-25d-frequency-domain
 
     D_{\text{linear},\,\text{2.5D}}(x_0,\w) = A(\w)
         \frac{4\i\chi(k_y,y_\text{ref})}
@@ -115,7 +116,7 @@ Assuming :math:`0 \le |k_{x_\text{s}}| \le |\wc |` this results in
 Transferred to the temporal domain this results in :cite:`Ahrens2010`, eq. (18)
 
 .. math::
-    :label: d.sdm.pw.2.5D
+    :label: d-sdm-plane-wave-25d-time-domain
 
     d_{\text{linear},\,\text{2.5D}}(x_0,t) = h(t) *
         a\left(t-\frac{x_0}{c}\sin\phi_k-\frac{y_\text{ref}}{c}\sin\phi_k\right),
@@ -123,7 +124,7 @@ Transferred to the temporal domain this results in :cite:`Ahrens2010`, eq. (18)
 where :math:`\phi_k` denotes the azimuth direction of the plane wave and
 
 .. math::
-    :label: h.sdm
+    :label: h-sdm
 
     h(t) = {\mathcal{F}^{-1}\left\{\frac{4\i}
         {\Hankel{2}{0}{k_y y_\text{ref}}}\right\}}.
@@ -167,17 +168,18 @@ Point Source
     :align: center
 
     Sound pressure for a monochromatic point source synthesized with 2.5D
-    |NFC-HOA| :eq:`D.nfchoa.ps.2.5D`.  Parameters: :math:`\xs = (0, 2.5, 0)` m,
-    :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
+    |NFC-HOA| :eq:`d-nfchoa-point-source-25d-frequency-domain`.  Parameters:
+    :math:`\xs = (0, 2.5, 0)` m, :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
 
 For a spherical secondary source distribution with radius :math:`R_0` the
 spherical coefficients of a point
 source :eq:`point-source-spherical-coefficients` and of the Green’s
-function :eq:`G_spherical` are inserted into :eq:`D_spherical` and yield
-:cite:`Ahrens2012`, eq. (5.7) [#F1]_
+function :eq:`g-spherical-frequency-domain` are inserted
+into :eq:`d-spherical-frequency-domain` and yield :cite:`Ahrens2012`, eq. (5.7)
+[#F1]_
 
 .. math::
-    :label: D.nfchoa.ps.3D
+    :label: d-nfchoa-point-source-3d-frequency-domain
 
     D_\text{spherical}(\theta_0,\phi_0,\w) =
         A(\w) \frac{1}{R_0^{\,2}} \sum_{n=0}^\infty \sum_{m=-n}^n
@@ -188,11 +190,12 @@ function :eq:`G_spherical` are inserted into :eq:`D_spherical` and yield
 For a circular secondary source distribution with radius :math:`R_0` and point
 source as secondary sources the 2.5D driving function is given by inserting the
 spherical coefficients :eq:`point-source-spherical-coefficients`
-and :eq:`G_spherical` into :eq:`D_circular_25D`. This results in
-:cite:`Ahrens2012`, eq. (5.8)
+and :eq:`g-spherical-frequency-domain`
+into :eq:`d-circular-25d-frequency-domain`. This results in :cite:`Ahrens2012`,
+eq. (5.8)
 
 .. math::
-    :label: D.nfchoa.ps.2.5D
+    :label: d-nfchoa-point-source-25d-frequency-domain
 
     D_{\text{circular},\,\text{2.5D}}(\phi_0,\w) =
         A(\w) \frac{1}{2\pi R_0} \sum_{m=-\infty}^{\infty}
@@ -203,12 +206,13 @@ and :eq:`G_spherical` into :eq:`D_circular_25D`. This results in
 For an infinite linear secondary source distribution located on the
 :math:`x`-axis and point sources as secondary sources the 2.5D driving function
 for a point source is given by inserting the corresponding linear expansion
-coefficients :eq:`point-source-linear-coefficients` and :eq:`G_linear`
-into :eq:`D_linear_25D`.  Assuming :math:`0 \le |k_x| < |\wc |` this
-results in :cite:`Ahrens2012`, eq. (4.53)
+coefficients :eq:`point-source-linear-coefficients`
+and :eq:`g-linear-frequency-domain` into :eq:`d-linear-25d-frequency-domain`.
+Assuming :math:`0 \le |k_x| < |\wc |` this results in :cite:`Ahrens2012`, eq.
+(4.53)
 
 .. math::
-    :label: D.sdm.ps.2.5D
+    :label: d-sdm-point-source-25d-frequency-domain
 
     \begin{aligned}
         D_{\text{linear},\,\text{2.5D}}(x_0,\w) =&
@@ -227,11 +231,11 @@ Line Source
 
 For a spherical secondary source distribution with radius :math:`R_0` the spherical
 coefficients of a line source :eq:`line-source-spherical-coefficients` and of
-the Green's function :eq:`G_spherical` are inserted into :eq:`D_spherical` and
-yield :cite:`Hahn2015`, eq. (20)
+the Green's function :eq:`g-spherical-frequency-domain` are inserted into
+:eq:`d-spherical-frequency-domain` and yield :cite:`Hahn2015`, eq. (20)
 
 .. math::
-    :label: D.nfchoa.ls.3D
+    :label: d-nfchoa-line-source-3d-frequency-domain
 
     D_{\text{spherical}}(\theta_0,\phi_0,\w) = A(\w) \frac{1}{2 R_0^2}
         \sum_{n=0}^{\infty} \sum_{m=-n}^{n}
@@ -243,10 +247,10 @@ yield :cite:`Hahn2015`, eq. (20)
 For a circular secondary source distribution with radius :math:`R_0` and line
 sources as secondary sources the driving function is given by inserting the
 circular coefficients :eq:`line-source-circular-coefficients`
-and :eq:`G_circular` into :eq:`D_circular` as
+and :eq:`g-circular-frequency-domain` into :eq:`d-circular-frequency-domain` as
 
 .. math::
-    :label: D.nfchoa.ls.2D
+    :label: d-nfchoa-line-source-2d-frequency-domain
 
     D_{\text{circular}}(\phi_0,\w) = A(\w) \frac{1}{2\pi R_0}
         \sum_{m=-\infty}^{\infty}
@@ -257,11 +261,11 @@ and :eq:`G_circular` into :eq:`D_circular` as
 For a circular secondary source distribution with radius :math:`R_0` and point
 sources as secondary sources the 2.5D driving function is given by inserting the
 spherical coefficients :eq:`line-source-spherical-coefficients`
-and :eq:`G_spherical` into :eq:`D_circular_25D` after :cite:`Hahn2015`, eq. (23)
-as
+and :eq:`g-spherical-frequency-domain` into
+:eq:`d-circular-25d-frequency-domain` after :cite:`Hahn2015`, eq. (23) as
 
 .. math::
-    :label: D.nfchoa.ls.2.5D
+    :label: d-nfchoa-line-source-25d-frequency-domain
 
     D_{\text{circular},\,\text{2.5D}}(\phi_0,\w) =
         A(\w) \frac{1}{2 R_0} \sum_{m=-\infty}^{\infty}
@@ -273,10 +277,10 @@ as
 For an infinite linear secondary source distribution located on the
 :math:`x`-axis and line sources as secondary sources the driving function is
 given by inserting the linear coefficients :eq:`line-source-linear-coefficients`
-and :eq:`G_linear` into :eq:`D_linear` as
+and :eq:`g-linear-frequency-domain` into :eq:`d-linear-frequency-domain` as
 
 .. math::
-    :label: D.sdm.ls.2D
+    :label: d-sdm-line-source-2d-frequency-domain
 
     D_\text{linear}(x_0,\w) = A(\w) \frac{1}{2\pi}
         \int_{-\infty}^\infty \chi(k_y,y_s) \chi(k_x,x_0) \d k_x.

--- a/d_wfs/index.rst
+++ b/d_wfs/index.rst
@@ -47,22 +47,23 @@ Plane Wave
 .. figure:: wfs-25d-plane-wave.*
     :align: center
 
-    Sound pressure for a monochromatic plane wave synthesized with 2.5D
-    |WFS| :eq:`D.wfs.ps.2.5D`.  Parameters: :math:`\n_k = (0, -1, 0)`,
-    :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
+    Sound pressure for a monochromatic plane wave synthesized with 2.5D |WFS|
+    :eq:`d-wfs-point-source-25d-frequency-domain`.  Parameters: :math:`\n_k =
+    (0, -1, 0)`, :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
 
-By inserting the source model of a plane wave :eq:`S.pw` into :eq:`D_wfs`
-and :eq:`D25D_wfs` it follows
+By inserting the source model of a plane
+wave :eq:`plane-wave-frequency-domain` into :eq:`d-wfs-frequency-domain`
+and :eq:`d-wfs-25d-frequency-domain` it follows
 
 .. math::
-    :label: D.wfs.pw
+    :label: d-wfs-plane-wave-frequency-domain
 
     D(\x_0,\w) = 2 w(\x_0) A(\w)
         \i\wc  \scalarprod{\n_k}{\n_{\x_0}}
         \e{-\i\wc  \scalarprod{\n_k}{\x_0}},
 
 .. math::
-    :label: D.wfs.pw.2.5D
+    :label: d-wfs-plane-wave-25d-frequency-domain
 
     D_\text{2.5D}(\x_0,\w) = 2 w(\x_0) A(\w)
         \sqrt{2\pi|\xref-x_0|}
@@ -73,13 +74,13 @@ Transferred to the temporal domain via an inverse Fourier transform :eq:`ifft`,
 it follows
 
 .. math::
-    :label: d.wfs.pw
+    :label: d-wfs-plane-wave-time-domain
 
     d(\x_0,t) = 2 a(t) * h(t) * w(\x_0) \scalarprod{\n_k}{\n_{\x_0}}
         \dirac{t - \frac{\scalarprod{\n_k}{\x_0}}{c}},
 
 .. math::
-    :label: d.wfs.pw.2.5D
+    :label: d-wfs-plane-wave-25d-time-domain
 
     \begin{aligned}
         d_\text{2.5D}(\x_0,t) =& 2 a(t) * h_\text{2.5D}(t) * w(\x_0)
@@ -91,14 +92,14 @@ it follows
 where
 
 .. math::
-    :label: h.wfs
+    :label: h-wfs
 
     h(t) = \mathcal{F}^{-1}\left\{\i\wc \right\},
 
 and
 
 .. math::
-    :label: h.wfs.2.5D
+    :label: h-wfs-25d
 
     h_\text{2.5D}(t) = \mathcal{F}^{-1}\left\{
         \sqrt{\i\wc }\right\}
@@ -109,7 +110,7 @@ The window function :math:`w(\x_0)` for a plane wave as source model can be
 calculated after :cite:`Spors2008` as
 
 .. math::
-    :label: wfs.pw.selection
+    :label: wfs-secondary-source-selection-plane-wave
 
     w(\x_0) = 
         \begin{cases}
@@ -153,15 +154,16 @@ Point Source
 .. figure:: wfs-25d-point-source.*
     :align: center
 
-    Sound pressure for a monochromatic point source synthesized with 2.5D
-    |WFS| :eq:`D.wfs.ps.2.5D`.  Parameters: :math:`\xs = (0, 2.5, 0)` m,
-    :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
+    Sound pressure for a monochromatic point source synthesized with 2.5D |WFS|
+    :eq:`d-wfs-point-source-25d-frequency-domain`.  Parameters: :math:`\xs = (0,
+    2.5, 0)` m, :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
 
-By inserting the source model for a point source :eq:`S.ps` into :eq:`D_wfs`
+By inserting the source model for a point
+source :eq:`point-source-frequency-domain` into :eq:`d-wfs-frequency-domain`
 it follows
 
 .. math::
-    :label: D.wfs.ps.woapprox
+    :label: d-wfs-point-source-woapprox-frequency-domain
 
     D(\x_0,\w) =
         \frac{1}{2\pi} A(\w) w(\x_0) \i\wc
@@ -170,10 +172,11 @@ it follows
         \e{-\i\wc |\x_0-\xs|}.
 
 Under the assumption of :math:`\wc |\x_0-\xs| \gg 1`,
-:eq:`D.wfs.ps.woapprox` can be approximated by :cite:`Schultz2016`, eq. (2.118)
+:eq:`d-wfs-point-source-woapprox-frequency-domain` can be approximated by
+:cite:`Schultz2016`, eq. (2.118)
 
 .. math::
-    :label: D.wfs.ps
+    :label: d-wfs-point-source-frequency-domain
 
     D(\x_0,\w) = \frac{1}{2\pi} A(\w) w(\x_0) \i\wc
         \frac{\scalarprod{\x_0-\xs}{\n_{\x_0}}}{|\x_0-\xs|^2}
@@ -183,13 +186,13 @@ It has the advantage that its temporal domain version could again be implemented
 as a simple weighting- and delaying-mechanism.
 
 To reach at 2.5D for a point source, we will start in 3D and apply stationary
-phase approximations instead of directly using :eq:`D25D_wfs` -- see discussion
-after :cite:`Schultz2016`, (2.146). Under the assumption of :math:`\frac{\omega}{c}
-(|\x_0-\xs| + |\x-\x_0|) \gg 1` it then follows :cite:`Schultz2016`, eq.
-(2.137), :cite:`Start1997`, eq. (3.10, 3.11)
+phase approximations instead of directly using :eq:`d-wfs-25d-frequency-domain`
+-- see discussion after :cite:`Schultz2016`, (2.146). Under the assumption of
+:math:`\frac{\omega}{c} (|\x_0-\xs| + |\x-\x_0|) \gg 1` it then follows
+:cite:`Schultz2016`, eq.  (2.137), :cite:`Start1997`, eq. (3.10, 3.11)
 
 .. math::
-    :label: D.wfs.ps.2.5D
+    :label: d-wfs-point-source-25d-frequency-domain
 
     \begin{aligned}
         D_\text{2.5D}(\x_0,\w) =&
@@ -205,7 +208,7 @@ A second stationary phase approximation can be applied to reach at
 :cite:`Schultz2016`, eq. (2.131, 2.141), :cite:`Start1997`, eq. (3.16, 3.17)
 
 .. math::
-    :label: D.wfs.ps.2.5D.refline
+    :label: d-wfs-point-source-25D-refline-frequency-domain
 
     \begin{aligned}
         D_\text{2.5D}(\x_0,\w) =&
@@ -223,18 +226,19 @@ the shortest possible distance from the point source to the linear secondary
 source distribution.
 
 The default |WFS| driving functions for a point source in the SFS Toolbox are
-:eq:`D.wfs.ps` and :eq:`D.wfs.ps.2.5D`.  Transferring both to the temporal
-domain via an inverse Fourier transform :eq:`ifft` it follows
+:eq:`d-wfs-point-source-frequency-domain` and
+:eq:`d-wfs-point-source-25d-frequency-domain`.  Transferring both to the
+temporal domain via an inverse Fourier transform :eq:`ifft` it follows
 
 .. math::
-    :label: d.wfs.ps
+    :label: d-wfs-point-source-time-domain
 
     d(\x_0,t) = \frac{1}{2{\pi}} a(t) * h(t) * w(\x_0)
         \frac{\scalarprod{\x_0-\xs}{\n_{\x_0}}}{|\x_0-\xs|^2}
         \dirac{t-\frac{|\x_0-\xs|}{c}},
 
 .. math::
-    :label: d.wfs.ps.2.5D
+    :label: d-wfs-point-source-25d-time-domain
 
     \begin{aligned}
         d_\text{2.5D}(\x_0,t) =&
@@ -246,7 +250,7 @@ domain via an inverse Fourier transform :eq:`ifft` it follows
     \end{aligned}
 
 .. math::
-    :label: d.wfs.ps.2.5D.refline
+    :label: d-wfs-point-source-25d-refline-time-domain
 
     \begin{aligned}
     d_\text{2.5D}(\x_0,t) =&
@@ -261,7 +265,7 @@ The window function :math:`w(\x_0)` for a point source as source model can be
 calculated after :cite:`Spors2008` as
 
 .. math::
-    :label: wfs.ps.selection
+    :label: wfs-secondary-source-selection-point-source
 
     w(\x_0) = 
         \begin{cases}
@@ -304,16 +308,16 @@ Line Source
 .. figure:: wfs-25d-line-source.*
     :align: center
 
-    Sound pressure for a monochromatic line source synthesized with 2D
-    |WFS| :eq:`D.wfs.ls`.  Parameters: :math:`\xs = (0, 2.5, 0)` m,
-    :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
+    Sound pressure for a monochromatic line source synthesized with 2D |WFS|
+    :eq:`d-wfs-line-source-frequency-domain`.  Parameters: :math:`\xs = (0, 2.5,
+    0)` m, :math:`\xref = (0, 0, 0)`, :math:`f = 1` kHz.
 
 For a line source its orientation :math:`\n_\text{s}` has an influence on the
 synthesized sound field as well.  Let :math:`|\vec{v}|` be the distance between
 :math:`\x_0` and the line source with
 
 .. math::
-    :label: v.ls
+    :label: v-line-source
 
     \vec{v} = \x_0-\xs - \scalarprod{\x_0-\xs}{\n_\text{s}} \n_\text{s},
 
@@ -322,19 +326,20 @@ a line source orientation perpendicular to the plane where the
 secondary sources are located this automatically simplifies to :math:`\vec{v} =
 \x_0 - \xs`.
 
-By inserting the source model for a line source :eq:`S.ls` into :eq:`D_wfs`
-and :eq:`D25D_wfs` and calculating the derivate of the Hankel function after
-`<http://dlmf.nist.gov/10.6.E6>`_ it follows
+By inserting the source model for a line
+source :eq:`line-source-frequency-domain` into :eq:`d-wfs-frequency-domain`
+and :eq:`d-wfs-25d-frequency-domain` and calculating the derivate of the Hankel
+function after `<http://dlmf.nist.gov/10.6.E6>`_ it follows
 
 .. math::
-    :label: D.wfs.ls
+    :label: d-wfs-line-source-frequency-domain
 
     D(\x_0,\w) = -\frac{1}{2}A(\w) w(\x_0) \i\wc
         \frac{\scalarprod{\vec{v}}{\n_{\x_0}}}{|\vec{v}|}
         \Hankel{2}{1}{\wc |\vec{v}|},
 
 .. math::
-    :label: D.wfs.ls.2.5D
+    :label: d-wfs-line-source-25d-frequency-domain
 
     D_\text{2.5D}(\x_0,\w) =
         -\frac{1}{2}g_0 A(\w) w(\x_0) \sqrt{\i\wc}
@@ -348,14 +353,14 @@ transferred to the temporal domain via an inverse Fourier transform :eq:`ifft`
 it follows
 
 .. math::
-    :label: d.wfs.ls
+    :label: d-wfs-line-source-time-domain
 
     d(\x_0,t) = \sqrt{\frac{1}{2\pi}} a(t) * h(t) * w(\x0)
         \frac{\scalarprod{\vec{v}}{\n_{\x_0}}}{|\vec{v}|^{\frac{3}{2}}}
         \dirac{t-\frac{|\vec{v}|}{c}},
 
 .. math::
-    :label: d.wfs.ls.2.5D
+    :label: d-wfs-line-source-25d-time-domain
 
     d_\text{2.5D}(\x_0,t) =
         g_0 \sqrt{\frac{1}{2\pi}} a(t) *
@@ -368,7 +373,7 @@ The window function :math:`w(\x_0)` for a line source as source model can be
 calculated after :cite:`Spors2008` as
 
 .. math::
-    :label: wfs.ls.selection
+    :label: wfs-secondary-source-selection-line-source
 
     w(\x_0) = 
         \begin{cases}
@@ -414,9 +419,9 @@ Focused Source
     :align: center
 
     Sound pressure for a monochromatic focused source synthesized with 2.5D
-    |WFS| :eq:`D.wfs.fs.2.5D`.  Parameters: :math:`\xs = (0, 0.5, 0)` m,
-    :math:`\n_\text{s} = (0, -1, 0)`, :math:`\xref = (0, 0, 0)`, :math:`f = 1`
-    kHz.
+    |WFS| :eq:`d-wfs-focused-source-25d-frequency-domain`.  Parameters:
+    :math:`\xs = (0, 0.5, 0)` m, :math:`\n_\text{s} = (0, -1, 0)`, :math:`\xref
+    = (0, 0, 0)`, :math:`f = 1` kHz.
 
 As mentioned before, focused sources exhibit a field that converges in a focal
 point inside the audience area. After passing the focal point, the field becomes
@@ -425,22 +430,23 @@ to choose the active secondary sources, especially for circular or spherical
 geometries, the focused source also needs a direction :math:`\n_\text{s}`.
 
 The driving function for a focused source is given by the time-reversed
-versions of the driving function for a point source :eq:`d.wfs.ps` and
-:eq:`d.wfs.ps.2.5D` as
+versions of the driving function for a point source
+:eq:`d-wfs-point-source-time-domain` and
+:eq:`d-wfs-point-source-25d-time-domain` as
 
 .. math::
-    :label: D.wfs.fs
+    :label: d-wfs-focused-source-frequency-domain
 
     D(\x_0,\w) = \frac{1}{2\pi} A(\w) w(\x_0) \i\wc
         \frac{\scalarprod{\x_0-\xs}{\n_{\x_0}}}{|\x_0-\xs|^2}
         \e{\i\wc |\x_0-\xs|}.
 
 The 2.5D driving functions are given by the time-reversed version of
-:eq:`d.wfs.ps.2.5D` for a reference point after :cite:`Verheijen1997`,
-eq. (A.14) as
+:eq:`d-wfs-point-source-25d-time-domain` for a reference point after
+:cite:`Verheijen1997`, eq. (A.14) as
 
 .. math::
-    :label: D.wfs.fs.2.5D
+    :label: d-wfs-focused-source-25d-frequency-domain
 
     \begin{aligned}
         D_\text{2.5D}(\x_0,\w) =&
@@ -451,11 +457,12 @@ eq. (A.14) as
             \e{\i\wc |\x_0-\xs|},
     \end{aligned}
 
-and the time reversed version of :eq:`d.wfs.ps.2.5D.refline` for a reference
-line, compare :cite:`Start1997`, eq. (3.16)
+and the time reversed version of
+:eq:`d-wfs-point-source-25d-refline-time-domain` for a reference line, compare
+:cite:`Start1997`, eq. (3.16)
 
 .. math::
-    :label: D.wfs.fs.2.5D.refline
+    :label: d-wfs-focused-source-25d-refline-frequency-domain
 
     \begin{aligned}
         D_\text{2.5D}(\x_0,\w) =&
@@ -474,14 +481,14 @@ Transferred to the temporal domain via an inverse Fourier transform :eq:`ifft` 
 follows
 
 .. math::
-    :label: d.wfs.fs
+    :label: d-wfs-focused-source-time-domain
 
     d(\x_0,t) = \frac{1}{2{\pi}} a(t) * h(t) * w(\x_0)
         \frac{\scalarprod{\x_0-\xs}{\n_{\x_0}}}{|\x_0-\xs|^2}
         \dirac{t+\frac{|\x_0-\xs|}{c}},
 
 .. math::
-    :label: d.wfs.fs.2.5D
+    :label: d-wfs-focused-source-25d-time-domain
 
     \begin{aligned}
         d_\text{2.5D}(\x_0,t) =&
@@ -493,7 +500,7 @@ follows
     \end{aligned}
 
 .. math::
-    :label: d.wfs.fs.2.5D.refline
+    :label: d-wfs-focused-source-25d-refline-time-domain
 
     \begin{aligned}
         d_\text{2.5D}(\x_0,t) =&
@@ -506,10 +513,10 @@ follows
 
 In this document a focused source always refers to the time-reversed version of a
 point source, but a focused line source can be defined in the same way starting
-from :eq:`D.wfs.ls`
+from :eq:`d-wfs-line-source-frequency-domain`
 
 .. math::
-    :label: D.wfs.fs.ls
+    :label: d-wfs-focused-line-source-frequency-domain
 
     D(\x_0,\w) = -\frac{1}{2}A(\w) w(\x_0) \i\wc 
         \frac{\scalarprod{\x_0-\xs}{\n_{\x_0}}}{|\x_0-\xs|}
@@ -519,7 +526,7 @@ Transferred to the temporal domain via an inverse Fourier transform :eq:`ifft`
 it follows
 
 .. math::
-    :label: d.wfs.fs.ls
+    :label: d-wfs-focused-line-source-time-domain
 
     d(\x_0,t) = \sqrt{\frac{1}{2\pi}} a(t) * h(t) * w(\x0)
         \frac{\scalarprod{\x_0-\xs}{\n_{\x_0}}}{|\x_0-\xs|^{\frac{3}{2}}}
@@ -528,7 +535,7 @@ it follows
 The window function :math:`w(\x_0)` for a focused source can be calculated as
 
 .. math::
-    :label: wfs.fs.selection
+    :label: wfs-secondary-source-selection-focused-source
 
     w(\x_0) = 
         \begin{cases}

--- a/dims/index.rst
+++ b/dims/index.rst
@@ -52,12 +52,13 @@ correct at a given reference point :math:`\xref`.
 
 For a circular secondary source distribution with point source characteristic
 the 2.5D driving function can be derived by introducing expansion coefficients
-for the spherical case into the driving function :eq:`D_circular`. The equation
-is than solved for :math:`\theta = 0{^\circ}` and :math:`r_\text{ref} = 0`. This
-results in a 2.5D driving function given after :cite:`Ahrens2012`, eq. (3.49) as
+for the spherical case into the driving
+function :eq:`d-circular-frequency-domain`. The equation is than solved for
+:math:`\theta = 0{^\circ}` and :math:`r_\text{ref} = 0`. This results in a 2.5D
+driving function given after :cite:`Ahrens2012`, eq. (3.49) as
 
 .. math::
-    :label: D_circular_25D
+    :label: d-circular-25d-frequency-domain
 
     D_{\text{circular},\text{2.5D}}(\phi_0,\w) = \frac{1}{2\pi R_0}
         \sum_{m=-\infty}^\infty \frac{\breve{S}_{|m|}^m
@@ -67,12 +68,12 @@ results in a 2.5D driving function given after :cite:`Ahrens2012`, eq. (3.49) as
 For a linear secondary source distribution with point source characteristics the
 2.5D driving function is derived by introducing the linear expansion
 coefficients for a monopole source :eq:`point-source-linear-coefficients` into
-the driving function :eq:`D_linear` and solving the equation for :math:`y =
-y_\text{ref}` and :math:`z = 0`. This results in a 2.5D driving function given
-after :cite:`Ahrens2012`, eq. (3.77) as
+the driving function :eq:`d-linear-frequency-domain` and solving the equation
+for :math:`y = y_\text{ref}` and :math:`z = 0`. This results in a 2.5D driving
+function given after :cite:`Ahrens2012`, eq. (3.77) as
 
 .. math::
-    :label: D_linear_25D
+    :label: d-linear-25d-frequency-domain
 
     D_{\text{linear},\text{2.5D}}(x_0,\w) = \frac{1}{2\pi}
         \int_{-\infty}^\infty \frac{\breve{S}(k_x,y_\text{ref},0,\w)}
@@ -87,7 +88,7 @@ Using this the following relationship between the 2D and 3D Green’s functions
 can be established.
 
 .. math::
-    :label: 25D_approximation
+    :label: 25d-approximation
 
     \begin{gathered}
         \underbrace{-\frac{\i}{4} \;
@@ -105,7 +106,7 @@ zeroth order. Inserting this approximation into the single-layer potential for
 the 2D case results in
 
 .. math::
-    :label: single-layer_25D
+    :label: single-layer-25d
 
     P(\x,\w) = \oint_S \sqrt{2\pi\frac{c}{\i\w}
         |\x-\x_0|} \; D(\x_0,\w) G_\text{3D}(\x-\x0,\w) \d A(\x_0).
@@ -114,7 +115,7 @@ If the amplitude correction is further restricted to one reference point
 :math:`\xref`, the 2.5D driving function for |WFS| can be formulated as
 
 .. math::
-    :label: D25D_wfs
+    :label: d-wfs-25d-frequency-domain
 
     D_\text{2.5D}(\x_0,\w) = \underbrace{\sqrt{2\pi|\xref-\x_0|}}_{g_0}
         \sqrt{\frac{c}{\i\w}} \, D(\x_0,\w),

--- a/nfchoa/index.rst
+++ b/nfchoa/index.rst
@@ -10,17 +10,17 @@ basis functions.  Then the involved functions are expanded into the basis
 functions :math:`\psi_n` after :cite:`Morse1981`, p. (940) as
 
 .. math::
-    :label: G_expansion
+    :label: g-expansion-frequency-domain
 
     G(\x-\x_0, \w) = \sum_{n} \tilde{G}_n(\w) \psi_n^*(\x_0) \psi_n(\x)
 
 .. math::
-    :label: D_expansion
+    :label: d-expansion-frequency-domain
 
     D(\x_0, \w) = \sum_n \tilde{D}_n(\w) \psi_n(\x_0)
 
 .. math::
-    :label: S_expansion
+    :label: s-expansion-frequency-domain
 
     S(\x, \w) = \sum_n \tilde{S}_n(\w) \psi_n(\x),
 
@@ -31,18 +31,18 @@ If the underlying space is not compact the equations will involve an integration
 instead of a summation
 
 .. math::
-    :label: G_expansion_non_compact
+    :label: g-expansion-non-compact-frequency-domain
 
     G(\x-\x_0, \w) = \int \tilde{G}(\mu, \w) \psi^*(\mu, \x_0)
         \psi(\mu, \x) \d\mu
 
 .. math::
-    :label: D_expansion_non_compact
+    :label: d-expansion-non-compact-frequency-domain
 
     D(\x_0, \w) = \int \tilde{D}(\mu, \w) \psi(\mu, \x_0) \d\mu
 
 .. math::
-    :label: S_expansion_non_compact
+    :label: s-expansion-non-compact-frequency-domain
 
     S(\x, \w) = \int \tilde{S}(\mu, \w) \psi(\mu, \x) \d\mu,
 
@@ -50,20 +50,20 @@ where :math:`\d\mu` is the measure in the underlying space.
 Introducing these equations into :eq:`single-layer` one gets
 
 .. math::
-    :label: D_HOA
+    :label: d-hoa-frequency-domain
 
     \tilde{D}_n(\w) =
         \frac{\tilde{S}_n(\w)}{\tilde{G}_n(\w)}.
 
 This means that the Fredholm equation :eq:`single-layer` states a convolution.
-For geometries where the required orthogonal basis functions exist, :eq:`D_HOA`
-follows directly via the convolution theorem :cite:`Arfken2005`, eq. (1013).
-Due to the division of the desired sound field by the spectrum of the Green’s
-function this kind of approach has been named |SDM| :cite:`Ahrens2010`.  For
-circular and spherical geometries the term |NFC-HOA| is more common due to the
-corresponding basis functions. “Near-field compensated” highlights the usage of
-point sources as secondary sources in contrast to Ambisonics and |HOA| that
-assume plane waves as secondary sources.
+For geometries where the required orthogonal basis functions exist,
+:eq:`d-hoa-frequency-domain` follows directly via the convolution theorem
+:cite:`Arfken2005`, eq. (1013).  Due to the division of the desired sound field
+by the spectrum of the Green’s function this kind of approach has been named
+|SDM| :cite:`Ahrens2010`.  For circular and spherical geometries the term
+|NFC-HOA| is more common due to the corresponding basis functions. “Near-field
+compensated” highlights the usage of point sources as secondary sources in
+contrast to Ambisonics and |HOA| that assume plane waves as secondary sources.
 
 The challenge is to find a set of basis functions for a given geometry.
 In the following paragraphs three simple geometries and their widely
@@ -106,7 +106,7 @@ function is then given by a simple division after :cite:`Ahrens2012`, eq. (3.21)
 [#F2]_ as
 
 .. math::
-    :label: D_spherical
+    :label: d-spherical-frequency-domain
 
     \begin{gathered}
         D_\text{spherical}(\theta_0,\phi_0,\w) = \\
@@ -124,7 +124,7 @@ the north pole of the sphere :math:`\x_0 = (\frac{\pi}{2},0,R_0)`. For a point
 source this is given after :cite:`Schultz2014`, eq. (25) as
 
 .. math::
-    :label: G_spherical
+    :label: g-spherical-frequency-domain
 
     \breve{G}_n^0(\tfrac{\pi}{2},0,\w) =
         -\i\wc \sqrt{\frac{2n+1}{4\pi}}
@@ -160,7 +160,7 @@ driving function can be calculated by a convolution along the surface of the
 circle as explicitly shown by :cite:`Ahrens2009a` and is then given as
 
 .. math::
-    :label: D_circular
+    :label: d-circular-frequency-domain
 
     D_\text{circular}(\phi_0,\w) =
         \frac{1}{2\pi R_0} \sum_{m=-\infty}^\infty
@@ -174,7 +174,7 @@ secondary monopole source. For a line source located at :math:`\x_0 = (0,R_0)`
 this is given as
 
 .. math::
-    :label: G_circular
+    :label: g-circular-frequency-domain
 
     \breve{G}_m(0,\w) = -\frac{\i}{4}
         \Hankel{2}{m}{\wc R_0},
@@ -210,7 +210,7 @@ For an infinitely long secondary source distribution located on the
 convolution along the plane after :cite:`Ahrens2012`, eq. (3.65) as
 
 .. math::
-    :label: D_planar
+    :label: d-planar-frequency-domain
 
     D_\text{planar}(x_0,y_0,\w) = \frac{1}{4{\pi}^2} \iint_{-\infty}^\infty
        \frac{\breve{S}(k_x,y_\text{s},k_z,\w)}{\breve{G}(k_x,0,k_z,\w)}
@@ -222,7 +222,7 @@ planar expansion coefficients of a secondary point source after
 :cite:`Schultz2014`, eq. (49) with
 
 .. math::
-    :label: G_planar
+    :label: g-planar-frequency-domain
 
     \breve{G}(k_x,0,k_z,\w) = -\frac{\i}{2}
         \frac{1}{\sqrt{(\wc )^2-k_x^2-k_z^2}},
@@ -260,7 +260,7 @@ For an infinitely long secondary source distribution located on the
 by a convolution along this axis after :cite:`Ahrens2012`, eq. (3.73) as
 
 .. math::
-    :label: D_linear
+    :label: d-linear-frequency-domain
 
     D_\text{linear}(x_0,\w) = \frac{1}{2\pi} \int_{-\infty}^\infty
         \frac{\breve{S}(k_x,y_\text{s},\w)}{\breve{G}(k_x,0,\w)}
@@ -272,7 +272,7 @@ model, :math:`y_\text{s}`, :math:`z_\text{s}` its positional dependency, and
 with
 
 .. math::
-    :label: G_linear
+    :label: g-linear-frequency-domain
 
     \breve{G}(k_x,0,\w) = -\frac{\i}{2}
         \frac{1}{\sqrt{(\wc )^2-k_x^2}},

--- a/sources/index.rst
+++ b/sources/index.rst
@@ -45,14 +45,15 @@ Plane Wave
 .. figure:: plane-wave.*
     :align: center
 
-    Sound pressure for a monochromatic plane wave :eq:`S.pw` going into the direction
-    :math:`(1, 1, 0)`. Parameters: :math:`f = 800` Hz.
+    Sound pressure for a monochromatic plane wave
+    :eq:`plane-wave-frequency-domain` going into the direction :math:`(1, 1,
+    0)`. Parameters: :math:`f = 800` Hz.
 
 The source model for a plane wave is given after :cite:`Williams1999`,
 eq. (2.24) [#F1]_ as
 
 .. math::
-    :label: S.pw
+    :label: plane-wave-frequency-domain
 
     S(\x,\w) = A(\w) \e{-\i\wc \scalarprod{\n_k}{\x}},
 
@@ -62,7 +63,7 @@ where :math:`A(\w)` denotes the frequency spectrum of the source and
 Transformed in the temporal domain this becomes
 
 .. math::
-    :label: s.pw
+    :label: plane-wave-time-domain
 
     s(\x,t) = a(t) * \dirac{t -\frac{\scalarprod{\n_k}{\x}}{c}},
 
@@ -130,14 +131,15 @@ Point Source
 .. figure:: point-source.*
     :align: center
 
-    Sound pressure for a monochromatic point source :eq:`S.ps` placed at :math:`(0, 0, 0)`.
+    Sound pressure for a monochromatic point source
+    :eq:`point-source-frequency-domain` placed at :math:`(0, 0, 0)`.
     Parameters: :math:`f = 800` Hz.
 
 The source model for a point source is given by the three dimensional Green’s
 function after :cite:`Williams1999`, eq. (6.73) as
 
 .. math::
-    :label: S.ps
+    :label: point-source-frequency-domain
 
     S(\x,\w) = A(\w) \frac{1}{4\pi} \frac{\e{-\i
         \wc |\x-\xs|}}{|\x-\xs|},
@@ -147,7 +149,7 @@ where :math:`\xs` describes the position of the point source.
 Transformed to the temporal domain this becomes
 
 .. math::
-    :label: s.ps
+    :label: point-source-time-domain
 
     s(\x,t) = a(t) * \frac{1}{4\pi} \frac{1}{|\x-\xs|}
         \dirac{t - \frac{|\x-\xs|}{c}}.
@@ -209,7 +211,8 @@ Dipole Point Source
 .. figure:: dipole-point-source.*
     :align: center
 
-    Sound pressure for a monochromatic dipole point source :eq:`S.dps` placed at
+    Sound pressure for a monochromatic dipole point source
+    :eq:`dipole-point-source-frequency-domain` placed at
     :math:`(0, 0, 0)` and pointing towards :math:`(1, 0, 0)`.  Parameters:
     :math:`f = 800` Hz.
 
@@ -218,7 +221,7 @@ directional derivative of the three dimensional Green’s function with respect 
 :math:`{\n_\text{s}}` defining the orientation of the dipole source.
 
 .. math::
-    :label: S.dps
+    :label: dipole-point-source-frequency-domain
 
     \begin{aligned}
         S(\x,\w) &= A(\w) \frac{1}{4\pi}
@@ -234,7 +237,7 @@ directional derivative of the three dimensional Green’s function with respect 
 Transformed to the temporal domain this becomes
 
 .. math::
-    :label: s.dps
+    :label: dipole-point-source-time-domain
 
     s(\x,t) = a(t) *
         \left( \frac{1}{|\x-\xs|} + {\mathcal{F}^{-1}\left\{
@@ -271,14 +274,15 @@ Line Source
 .. figure:: line-source.*
     :align: center
 
-    Sound pressure for a monochromatic line source :eq:`S.ls` placed at :math:`(0, 0, 0)`.
-    Parameters: :math:`f = 800` Hz.
+    Sound pressure for a monochromatic line source
+    :eq:`line-source-frequency-domain` placed at :math:`(0, 0, 0)`.  Parameters:
+    :math:`f = 800` Hz.
 
 The source model for a line source is given by the two dimensional Green’s
 function after :cite:`Williams1999`, eq. (8.47) as
 
 .. math::
-    :label: S.ls
+    :label: line-source-frequency-domain
 
     S(\x,\w) = -A(\w) \frac{\i}{4} \Hankel{2}{0}{\wc |\x-\xs|}.
 
@@ -287,7 +291,7 @@ Applying the large argument approximation of the Hankel function
 becomes
 
 .. math::
-    :label: s.ls
+    :label: line-source-time-domain
 
     s(\x,t) = a(t) * \mathcal{F}^{-1}\left\{\sqrt{
         \frac{c}{\i\w}}\right\} * \sqrt{\frac{1}{8\pi}}

--- a/wfs/index.rst
+++ b/wfs/index.rst
@@ -15,7 +15,7 @@ the differences of the gradients approaching :math:`\partial V` from both sides
 after :cite:`Fazi2013` as
 
 .. math::
-    :label: D_gradient
+    :label: d-gradient-frequency-domain
 
     D(\x_0,\w) = \partial_\n P(\x_0,\w) +
         \partial_{-\n} P(\x_0,\w),
@@ -26,35 +26,36 @@ Due to the symmetry of the problem the solution for an infinite planar boundary
 :math:`\partial V` is given as
 
 .. math::
-    :label: D_wfs
+    :label: d-wfs-frequency-domain
 
     D(\x_0,\w) = -2 \partial_\n S(\x_0,\w),
 
 where the pressure in the outside region is the mirrored interior pressure given
-by the source model :math:`S(\x,\w)` for :math:`\x\in V`. The integral
-equation resulting from introducing :eq:`D_wfs` into :eq:`single-layer` for a
-planar boundary :math:`\partial V` is known as *Rayleigh’s first integral
+by the source model :math:`S(\x,\w)` for :math:`\x\in V`. The integral equation
+resulting from introducing :eq:`d-wfs-frequency-domain` into :eq:`single-layer`
+for a planar boundary :math:`\partial V` is known as *Rayleigh’s first integral
 equation*. This solution is identical to the explicit solution for planar
-geometries :eq:`D_planar` in :math:`{\mathbb{R}}^3` and for linear
-geometries :eq:`D_linear` in :math:`{\mathbb{R}}^2`.
+geometries :eq:`d-planar-frequency-domain` in :math:`{\mathbb{R}}^3` and for
+linear geometries :eq:`d-linear-frequency-domain` in :math:`{\mathbb{R}}^2`.
 
-A solution of :eq:`D_gradient` for arbitrary boundaries can be found by applying
-the *Kirchhoff* or *physical optics approximation* :cite:`Colton1983`, p. 53–54.
-In acoustics this is also known as *determining the visible elements* for the
-high frequency boundary element method :cite:`Herrin2003`.  Here, it is assumed
-that a bent surface can be approximated by a set of small planar surfaces for
-which :eq:`D_wfs` holds locally.  In general, this will be the case if the wave
-length is much smaller than the size of a planar surface patch and the position
-of the listener is far away from the secondary sources. [#F1]_ Additionally,
-only one part of the surface is active: the area that is illuminated from the
-incident field of the source model.
+A solution of :eq:`d-gradient-frequency-domain` for arbitrary boundaries can be
+found by applying the *Kirchhoff* or *physical optics approximation*
+:cite:`Colton1983`, p. 53–54.  In acoustics this is also known as *determining
+the visible elements* for the high frequency boundary element method
+:cite:`Herrin2003`.  Here, it is assumed that a bent surface can be approximated
+by a set of small planar surfaces for which :eq:`d-wfs-frequency-domain` holds
+locally.  In general, this will be the case if the wave length is much smaller
+than the size of a planar surface patch and the position of the listener is far
+away from the secondary sources. [#F1]_ Additionally, only one part of the
+surface is active: the area that is illuminated from the incident field of the
+source model.
 
 The outlined approximation can be formulated by introducing a window function
 :math:`w(\x_0)` for the selection of the active secondary sources
-into :eq:`D_wfs` as
+into :eq:`d-wfs-frequency-domain` as
 
 .. math::
-    :label: P_wfs
+    :label: p-wfs-frequency-domain
 
     P(\x,\w) \approx \oint_{\partial V} \!\!  G(\x|\x_0,\w) \,
         \underbrace{-2 w(\x_0) \partial_\n S(\x_0,\w)}_{D(\x_0,\w)}
@@ -67,9 +68,9 @@ secondary source distributions can be used with |WFS| – compare the appendix i
 :cite:`Lax1947` [#F2]_.
 
 One of the advantages of the applied approximation is that due to its local
-character the solution of the driving function :eq:`D_wfs` does not depend on
-the geometry of the secondary sources. This dependency applies to the direct
-solutions presented in :ref:`sec-nfchoa`.
+character the solution of the driving function :eq:`d-wfs-frequency-domain` does
+not depend on the geometry of the secondary sources. This dependency applies to
+the direct solutions presented in :ref:`sec-nfchoa`.
 
 .. [#F1]
     Compare the assumptions made before (15) in :cite:`Spors2013`, which lead


### PR DESCRIPTION
This also dates back to the email discussion from 2017-12-18.

It tries to achive the following:

* Always use lower case, e.g. d instead of D
* Always use `-` instead of `_` or `.`
* Add domain (time, frequency, ...) to the equation when neccessary

Note, the last point is critical as it involves the discussion from https://github.com/sfstoolbox/sfs-python/issues/25 which isn't completely solved yet. So far I decided to use a long naming convention and added `-frequency-domain` and `-time-domain` at the end of the labels. In addition, I use `point-source` instead of `ps`. This might be a problem as the resulting links could look like this:
`http://sfstoolbox.org/wfs-drivingfunctions.html#equation-d-wfs-point-source-25d-time-domain`, which would be 92 characters and is not very elegant for including it into any doc string.

As the labels are unique we could shorten it with automatic redirection as we also discussed in the email, then it would be:
`http://sfstoolbox.org/d-wfs-point-source-25d-time-domain`.

Alternative, we could use abbreviations like this:
`http://sfstoolbox.org/wfs-drivingfunctions/#eq-d-wfs-ps-25d-td`.

I'm not sure yet what the best solution will be.